### PR TITLE
feat: add country code picker for phone number input

### DIFF
--- a/.github/GITHUB_ACTIONS.md
+++ b/.github/GITHUB_ACTIONS.md
@@ -2,8 +2,6 @@
 
 This directory contains the complete GitHub Actions deployment pipeline for Auth0 Universal Login customizations.
 
-## Directory Structure
-
 ```
 .github/
 ├── config/                      # Configuration files

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ coverage
 *.njsproj
 *.sln
 *.sw?
+docs

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -13,7 +13,6 @@ This document provides a comprehensive guide to set up the infrastructure and co
 - [Deployment Options](#deployment-options)
 - [Usage](#usage)
 - [Troubleshooting](#troubleshooting)
-- [Working Directory Configuration](#working-directory-configuration)
 
 <a id="overview"></a>
 
@@ -381,32 +380,3 @@ The workflow is designed to be resilient:
 - **Check:** Browser console for 404 errors on assets
 - **Solution:** Verify `S3_CDN_URL` is correct and assets are publicly accessible
 </details>
-
-<a id="logs-and-monitoring"></a>
-
-### Logs and Monitoring
-
-- 📊 The GitHub Actions workflow provides detailed logs for each step
-- 🔎 Each screen deployment includes asset discovery information
-- ✅ Successful and failed deployments are tracked and reported
-- 📑 The workflow outputs a summary at the end with links to deployed screens
-
-<a id="working-directory-configuration"></a>
-
-## 🗂️ Working Directory Configuration
-
-If you're using this workflow in a monorepo, the default setting assumes:
-
-```yaml
-env:
-  WORKING_DIR: /auth0-acul-samples
-```
-
-If your ACUL code is in the repository root, change this to:
-
-```yaml
-env:
-  WORKING_DIR: .
-```
-
-Adjust this path according to your repository structure.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ This project provides a template for creating custom Auth0 Advanced Customizatio
 
 <a id="project-structure"></a>
 
-## 📁 Project Structure
-
 ```
 auth0-acul-samples/
 ├── .github/             # GitHub Actions workflows for CI/CD

--- a/package-lock.json
+++ b/package-lock.json
@@ -3414,16 +3414,16 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.19",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
-      "integrity": "sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==",
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.0.tgz",
-      "integrity": "sha512-2o/FgACbji4tW1dzXOqAV15Eu7DdgbKsF2QKcxfG4xbh5iwU7yr5RRP5/U+0asQliSYv5M4o7BevlGIoSL0LXg==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.1.tgz",
+      "integrity": "sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==",
       "cpu": [
         "arm"
       ],
@@ -3435,9 +3435,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.45.0.tgz",
-      "integrity": "sha512-PSZ0SvMOjEAxwZeTx32eI/j5xSYtDCRxGu5k9zvzoY77xUNssZM+WV6HYBLROpY5CkXsbQjvz40fBb7WPwDqtQ==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.45.1.tgz",
+      "integrity": "sha512-ujQ+sMXJkg4LRJaYreaVx7Z/VMgBBd89wGS4qMrdtfUFZ+TSY5Rs9asgjitLwzeIbhwdEhyj29zhst3L1lKsRQ==",
       "cpu": [
         "arm64"
       ],
@@ -3449,9 +3449,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.0.tgz",
-      "integrity": "sha512-BA4yPIPssPB2aRAWzmqzQ3y2/KotkLyZukVB7j3psK/U3nVJdceo6qr9pLM2xN6iRP/wKfxEbOb1yrlZH6sYZg==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.1.tgz",
+      "integrity": "sha512-FSncqHvqTm3lC6Y13xncsdOYfxGSLnP+73k815EfNmpewPs+EyM49haPS105Rh4aF5mJKywk9X0ogzLXZzN9lA==",
       "cpu": [
         "arm64"
       ],
@@ -3463,9 +3463,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.45.0.tgz",
-      "integrity": "sha512-Pr2o0lvTwsiG4HCr43Zy9xXrHspyMvsvEw4FwKYqhli4FuLE5FjcZzuQ4cfPe0iUFCvSQG6lACI0xj74FDZKRA==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.45.1.tgz",
+      "integrity": "sha512-2/vVn/husP5XI7Fsf/RlhDaQJ7x9zjvC81anIVbr4b/f0xtSmXQTFcGIQ/B1cXIYM6h2nAhJkdMHTnD7OtQ9Og==",
       "cpu": [
         "x64"
       ],
@@ -3477,9 +3477,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.45.0.tgz",
-      "integrity": "sha512-lYE8LkE5h4a/+6VnnLiL14zWMPnx6wNbDG23GcYFpRW1V9hYWHAw9lBZ6ZUIrOaoK7NliF1sdwYGiVmziUF4vA==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.45.1.tgz",
+      "integrity": "sha512-4g1kaDxQItZsrkVTdYQ0bxu4ZIQ32cotoQbmsAnW1jAE4XCMbcBPDirX5fyUzdhVCKgPcrwWuucI8yrVRBw2+g==",
       "cpu": [
         "arm64"
       ],
@@ -3491,9 +3491,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.45.0.tgz",
-      "integrity": "sha512-PVQWZK9sbzpvqC9Q0GlehNNSVHR+4m7+wET+7FgSnKG3ci5nAMgGmr9mGBXzAuE5SvguCKJ6mHL6vq1JaJ/gvw==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.45.1.tgz",
+      "integrity": "sha512-L/6JsfiL74i3uK1Ti2ZFSNsp5NMiM4/kbbGEcOCps99aZx3g8SJMO1/9Y0n/qKlWZfn6sScf98lEOUe2mBvW9A==",
       "cpu": [
         "x64"
       ],
@@ -3505,9 +3505,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.45.0.tgz",
-      "integrity": "sha512-hLrmRl53prCcD+YXTfNvXd776HTxNh8wPAMllusQ+amcQmtgo3V5i/nkhPN6FakW+QVLoUUr2AsbtIRPFU3xIA==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.45.1.tgz",
+      "integrity": "sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==",
       "cpu": [
         "arm"
       ],
@@ -3519,9 +3519,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.45.0.tgz",
-      "integrity": "sha512-XBKGSYcrkdiRRjl+8XvrUR3AosXU0NvF7VuqMsm7s5nRy+nt58ZMB19Jdp1RdqewLcaYnpk8zeVs/4MlLZEJxw==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.45.1.tgz",
+      "integrity": "sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==",
       "cpu": [
         "arm"
       ],
@@ -3533,9 +3533,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.45.0.tgz",
-      "integrity": "sha512-fRvZZPUiBz7NztBE/2QnCS5AtqLVhXmUOPj9IHlfGEXkapgImf4W9+FSkL8cWqoAjozyUzqFmSc4zh2ooaeF6g==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.45.1.tgz",
+      "integrity": "sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==",
       "cpu": [
         "arm64"
       ],
@@ -3547,9 +3547,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.45.0.tgz",
-      "integrity": "sha512-Btv2WRZOcUGi8XU80XwIvzTg4U6+l6D0V6sZTrZx214nrwxw5nAi8hysaXj/mctyClWgesyuxbeLylCBNauimg==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.45.1.tgz",
+      "integrity": "sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==",
       "cpu": [
         "arm64"
       ],
@@ -3561,9 +3561,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.45.0.tgz",
-      "integrity": "sha512-Li0emNnwtUZdLwHjQPBxn4VWztcrw/h7mgLyHiEI5Z0MhpeFGlzaiBHpSNVOMB/xucjXTTcO+dhv469Djr16KA==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.45.1.tgz",
+      "integrity": "sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==",
       "cpu": [
         "loong64"
       ],
@@ -3575,9 +3575,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.45.0.tgz",
-      "integrity": "sha512-sB8+pfkYx2kvpDCfd63d5ScYT0Fz1LO6jIb2zLZvmK9ob2D8DeVqrmBDE0iDK8KlBVmsTNzrjr3G1xV4eUZhSw==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.45.1.tgz",
+      "integrity": "sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==",
       "cpu": [
         "ppc64"
       ],
@@ -3589,9 +3589,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.45.0.tgz",
-      "integrity": "sha512-5GQ6PFhh7E6jQm70p1aW05G2cap5zMOvO0se5JMecHeAdj5ZhWEHbJ4hiKpfi1nnnEdTauDXxPgXae/mqjow9w==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.45.1.tgz",
+      "integrity": "sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==",
       "cpu": [
         "riscv64"
       ],
@@ -3603,9 +3603,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.45.0.tgz",
-      "integrity": "sha512-N/euLsBd1rekWcuduakTo/dJw6U6sBP3eUq+RXM9RNfPuWTvG2w/WObDkIvJ2KChy6oxZmOSC08Ak2OJA0UiAA==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.45.1.tgz",
+      "integrity": "sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==",
       "cpu": [
         "riscv64"
       ],
@@ -3617,9 +3617,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.45.0.tgz",
-      "integrity": "sha512-2l9sA7d7QdikL0xQwNMO3xURBUNEWyHVHfAsHsUdq+E/pgLTUcCE+gih5PCdmyHmfTDeXUWVhqL0WZzg0nua3g==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.45.1.tgz",
+      "integrity": "sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==",
       "cpu": [
         "s390x"
       ],
@@ -3631,9 +3631,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.0.tgz",
-      "integrity": "sha512-XZdD3fEEQcwG2KrJDdEQu7NrHonPxxaV0/w2HpvINBdcqebz1aL+0vM2WFJq4DeiAVT6F5SUQas65HY5JDqoPw==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
+      "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
       "cpu": [
         "x64"
       ],
@@ -3645,9 +3645,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.45.0.tgz",
-      "integrity": "sha512-7ayfgvtmmWgKWBkCGg5+xTQ0r5V1owVm67zTrsEY1008L5ro7mCyGYORomARt/OquB9KY7LpxVBZes+oSniAAQ==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.45.1.tgz",
+      "integrity": "sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==",
       "cpu": [
         "x64"
       ],
@@ -3659,9 +3659,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.45.0.tgz",
-      "integrity": "sha512-B+IJgcBnE2bm93jEW5kHisqvPITs4ddLOROAcOc/diBgrEiQJJ6Qcjby75rFSmH5eMGrqJryUgJDhrfj942apQ==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.45.1.tgz",
+      "integrity": "sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==",
       "cpu": [
         "arm64"
       ],
@@ -3673,9 +3673,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.45.0.tgz",
-      "integrity": "sha512-+CXwwG66g0/FpWOnP/v1HnrGVSOygK/osUbu3wPRy8ECXjoYKjRAyfxYpDQOfghC5qPJYLPH0oN4MCOjwgdMug==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.45.1.tgz",
+      "integrity": "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw==",
       "cpu": [
         "ia32"
       ],
@@ -3687,9 +3687,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.0.tgz",
-      "integrity": "sha512-SRf1cytG7wqcHVLrBc9VtPK4pU5wxiB/lNIkNmW2ApKXIg+RpqwHfsaEK+e7eH4A1BpI6BX/aBWXxZCIrJg3uA==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.1.tgz",
+      "integrity": "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA==",
       "cpu": [
         "x64"
       ],
@@ -3701,9 +3701,9 @@
       ]
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.37",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.37.tgz",
-      "integrity": "sha512-2TRuQVgQYfy+EzHRTIvkhv2ADEouJ2xNS/Vq+W5EuuewBdOrvATvljZTxHWZSTYr2sTjTHpGvucaGAt67S2akw==",
+      "version": "0.34.38",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.38.tgz",
+      "integrity": "sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4289,9 +4289,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.16.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.3.tgz",
-      "integrity": "sha512-sr4Xz74KOUeYadexo1r8imhRtlVXcs+j3XK3TcoiYk7B1t3YRVJgtaD3cwX73NYb71pmVuMLNRhJ9XKdoDB74g==",
+      "version": "22.16.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.4.tgz",
+      "integrity": "sha512-PYRhNtZdm2wH/NT2k/oAJ6/f2VD2N2Dag0lGlx2vWgMSJXGNmlce5MiTQzoWAiIJtso30mjnfQCOKVH+kAQC/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4626,16 +4626,16 @@
       ]
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.6.0.tgz",
-      "integrity": "sha512-5Kgff+m8e2PB+9j51eGHEpn5kUzRKH2Ry0qGoe8ItJg7pqnkPrYPkDQZGgGmTa0EGarHrkjLvOdU3b1fzI8otQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.27.4",
+        "@babel/core": "^7.28.0",
         "@babel/plugin-transform-react-jsx-self": "^7.27.1",
         "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.19",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
         "@types/babel__core": "^7.20.5",
         "react-refresh": "^0.17.0"
       },
@@ -4643,7 +4643,7 @@
         "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -5468,9 +5468,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.182",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.182.tgz",
-      "integrity": "sha512-Lv65Btwv9W4J9pyODI6EWpdnhfvrve/us5h1WspW8B2Fb0366REPtY3hX7ounk1CkV/TBjWCEvCBBbYbmV0qCA==",
+      "version": "1.5.187",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.187.tgz",
+      "integrity": "sha512-cl5Jc9I0KGUoOoSbxvTywTa40uspGJt/BDBoDLoxJRSBpWh4FFXBsjNRHfQrONsV/OoEjDfHUmZQa2d6Ze4YgA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7547,9 +7547,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9057,9 +9057,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.0.tgz",
-      "integrity": "sha512-WLjEcJRIo7i3WDDgOIJqVI2d+lAC3EwvOGy+Xfq6hs+GQuAA4Di/H72xmXkOhrIWFg2PFYSKZYfH0f4vfKXN4A==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
+      "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9073,26 +9073,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.45.0",
-        "@rollup/rollup-android-arm64": "4.45.0",
-        "@rollup/rollup-darwin-arm64": "4.45.0",
-        "@rollup/rollup-darwin-x64": "4.45.0",
-        "@rollup/rollup-freebsd-arm64": "4.45.0",
-        "@rollup/rollup-freebsd-x64": "4.45.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.45.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.45.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.45.0",
-        "@rollup/rollup-linux-arm64-musl": "4.45.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.45.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.45.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.45.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.45.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.45.0",
-        "@rollup/rollup-linux-x64-gnu": "4.45.0",
-        "@rollup/rollup-linux-x64-musl": "4.45.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.45.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.45.0",
-        "@rollup/rollup-win32-x64-msvc": "4.45.0",
+        "@rollup/rollup-android-arm-eabi": "4.45.1",
+        "@rollup/rollup-android-arm64": "4.45.1",
+        "@rollup/rollup-darwin-arm64": "4.45.1",
+        "@rollup/rollup-darwin-x64": "4.45.1",
+        "@rollup/rollup-freebsd-arm64": "4.45.1",
+        "@rollup/rollup-freebsd-x64": "4.45.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.45.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.45.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.45.1",
+        "@rollup/rollup-linux-arm64-musl": "4.45.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.45.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.45.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.45.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.45.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.45.1",
+        "@rollup/rollup-linux-x64-gnu": "4.45.1",
+        "@rollup/rollup-linux-x64-musl": "4.45.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.45.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.45.1",
+        "@rollup/rollup-win32-x64-msvc": "4.45.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -9626,9 +9626,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10070,9 +10070,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/__mocks__/@auth0/auth0-acul-js/login-id.ts
+++ b/src/__mocks__/@auth0/auth0-acul-js/login-id.ts
@@ -23,6 +23,7 @@ export interface MockLoginIdInstance {
   federatedLogin: jest.Mock;
   passkeyLogin: jest.Mock;
   pickCountryCode: jest.Mock;
+  getError: jest.Mock;
   screen: ScreenMembersOnLoginId;
   transaction: TransactionMembersOnLoginId;
 }
@@ -37,6 +38,7 @@ export const createMockLoginIdInstance = (): MockLoginIdInstance => ({
   federatedLogin: jest.fn(),
   passkeyLogin: jest.fn(),
   pickCountryCode: jest.fn(),
+  getError: jest.fn(() => []), // Returns empty array by default
   screen: {
     name: "login-id",
     texts: {

--- a/src/common/CountryCodePicker/index.tsx
+++ b/src/common/CountryCodePicker/index.tsx
@@ -1,0 +1,111 @@
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+import { ChevronRight } from "lucide-react";
+
+export interface CountryCodePickerProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /**
+   * Selected country information
+   */
+  selectedCountry?: {
+    name: string;
+    code: string; // Country code like "DZ"
+    dialCode: string; // Phone code like "+213"
+    flag: string; // Flag emoji or URL
+  };
+  /**
+   * Placeholder text when no country is selected
+   */
+  placeholder?: string;
+  /**
+   * Loading state
+   */
+  isLoading?: boolean;
+  /**
+   * Full width styling
+   */
+  fullWidth?: boolean;
+}
+
+const CountryCodePicker = forwardRef<HTMLButtonElement, CountryCodePickerProps>(
+  (
+    {
+      selectedCountry,
+      placeholder = "Select Country",
+      isLoading = false,
+      fullWidth = false,
+      className,
+      disabled,
+      ...rest
+    },
+    ref,
+  ) => {
+    const baseStyles =
+      "inline-flex items-center justify-between px-4 py-4 bg-background-widget text-text-default border border-gray-mid hover:bg-primary/5 focus:bg-primary/15 focus:outline-none focus:ring-4 focus:ring-primary/15 transition-colors duration-150 ease-in-out text-md rounded font-medium text-left";
+
+    const widthStyles = fullWidth ? "w-full" : "";
+    const disabledStyles =
+      disabled || isLoading
+        ? "disabled:opacity-70 cursor-not-allowed"
+        : "cursor-pointer";
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        disabled={disabled || isLoading}
+        className={cn(baseStyles, widthStyles, disabledStyles, className)}
+        {...rest}
+      >
+        <div className="flex items-center space-x-3 flex-1 min-w-0">
+          {selectedCountry ? (
+            <>
+              {/* Flag */}
+              <div className="flex-shrink-0 w-6 h-4 flex items-center justify-center">
+                {selectedCountry.flag.startsWith("http") ? (
+                  <img
+                    src={selectedCountry.flag}
+                    alt={`${selectedCountry.name} flag`}
+                    className="w-6 h-4 object-cover rounded-sm"
+                  />
+                ) : (
+                  <span className="text-lg">{selectedCountry.flag}</span>
+                )}
+              </div>
+
+              {/* Country Info */}
+              <div className="flex-1 min-w-0">
+                <span className="text-gray-900 font-medium truncate">
+                  {selectedCountry.name}, {selectedCountry.code},{" "}
+                  {selectedCountry.dialCode}
+                </span>
+              </div>
+            </>
+          ) : (
+            <>
+              {/* Placeholder state */}
+              <div className="flex-shrink-0 w-6 h-4 bg-gray-200 rounded-sm"></div>
+              <span className="text-gray-500 flex-1 truncate">
+                {placeholder}
+              </span>
+            </>
+          )}
+        </div>
+
+        {/* Chevron */}
+        <div className="flex-shrink-0 ml-2">
+          <ChevronRight
+            className={cn(
+              "w-4 h-4 text-gray-400 transition-transform duration-200",
+              isLoading && "animate-pulse",
+            )}
+          />
+        </div>
+      </button>
+    );
+  },
+);
+
+CountryCodePicker.displayName = "CountryCodePicker";
+
+export default CountryCodePicker;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,7 @@ async function initializeApp() {
    * ACUL Integration Note:
    * The following lines handle the specific way this React application is integrated
    * into Auth0's Universal Login page. Auth0 provides the base HTML DOM.
-   * This script then dynamically creates a 'div' (rootElement),
+   * This script then creates a 'div' (rootElement),
    * appends it to Auth0's document.body, and then mounts the React application onto this div.
    * This differs from typical setups where an index.html is bundled directly with the app.
    */

--- a/src/mock-data/login-id.json
+++ b/src/mock-data/login-id.json
@@ -71,8 +71,8 @@
   },
   "transaction": {
     "country_code": {
-      "code": "AZ",
-      "prefix": "41"
+      "code": "IN",
+      "prefix": "91"
     },
     "alternate_connections": [
       {
@@ -103,9 +103,25 @@
         "signup_enabled": true,
         "forgot_password_enabled": true,
         "attributes": {
+          "email": {
+            "signup_status": "required",
+            "identifier_active": true
+          },
           "phone": {
             "signup_status": "required",
             "identifier_active": true
+          },
+          "username": {
+            "signup_status": "required",
+            "identifier_active": true,
+            "validation": {
+              "max_length": 15,
+              "min_length": 1,
+              "allowed_types": {
+                "email": false,
+                "phone_number": false
+              }
+            }
           }
         },
         "authentication_methods": {

--- a/src/mock-data/login-id.json
+++ b/src/mock-data/login-id.json
@@ -71,8 +71,8 @@
   },
   "transaction": {
     "country_code": {
-      "code": "IN",
-      "prefix": "91"
+      "code": "AZ",
+      "prefix": "41"
     },
     "alternate_connections": [
       {
@@ -103,25 +103,9 @@
         "signup_enabled": true,
         "forgot_password_enabled": true,
         "attributes": {
-          "email": {
-            "signup_status": "required",
-            "identifier_active": true
-          },
           "phone": {
             "signup_status": "required",
             "identifier_active": true
-          },
-          "username": {
-            "signup_status": "required",
-            "identifier_active": true,
-            "validation": {
-              "max_length": 15,
-              "min_length": 1,
-              "allowed_types": {
-                "email": false,
-                "phone_number": false
-              }
-            }
           }
         },
         "authentication_methods": {

--- a/src/screens/login-id/__tests__/index.test.tsx
+++ b/src/screens/login-id/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import LoginIdScreen from "../index";
 import LoginIdInstance from "@auth0/auth0-acul-js/login-id";
 import {
@@ -348,6 +348,41 @@ describe("LoginIdScreen", () => {
       });
       render(<LoginIdScreen />);
       expect(document.title).toBe("Custom Login Title");
+    });
+  });
+
+  describe("Country Code Picker Conditional Display", () => {
+    it("should NOT show country picker when phone is not supported", () => {
+      mockInstance.transaction.allowedIdentifiers = ["email", "username"];
+      render(<LoginIdScreen />);
+
+      // Should not have any country picker elements
+      expect(screen.queryByText("🇺🇸")).not.toBeInTheDocument();
+      expect(screen.queryByText("Select Country")).not.toBeInTheDocument();
+    });
+
+    it("should SHOW country picker when phone is supported", () => {
+      mockInstance.transaction.allowedIdentifiers = ["email", "phone"];
+      mockInstance.transaction.countryCode = null;
+      mockInstance.transaction.countryPrefix = null;
+      render(<LoginIdScreen />);
+
+      expect(screen.getByText("Select Country")).toBeInTheDocument();
+    });
+
+    it("should call pickCountryCode when clicked", async () => {
+      mockInstance.transaction.allowedIdentifiers = ["email", "phone"];
+      mockInstance.transaction.countryCode = null;
+      mockInstance.transaction.countryPrefix = null;
+      render(<LoginIdScreen />);
+
+      const countryPicker = screen
+        .getByText("Select Country")
+        .closest("button");
+      await act(async () => {
+        fireEvent.click(countryPicker!);
+      });
+      expect(mockInstance.pickCountryCode).toHaveBeenCalled();
     });
   });
 });

--- a/src/screens/login-id/__tests__/index.test.tsx
+++ b/src/screens/login-id/__tests__/index.test.tsx
@@ -352,17 +352,24 @@ describe("LoginIdScreen", () => {
   });
 
   describe("Country Code Picker Conditional Display", () => {
-    it("should NOT show country picker when phone is not supported", () => {
-      mockInstance.transaction.allowedIdentifiers = ["email", "username"];
+    it("should NOT show country picker when phone is mixed with other identifiers", () => {
+      mockInstance.transaction.allowedIdentifiers = ["email", "phone"];
       render(<LoginIdScreen />);
 
-      // Should not have any country picker elements
-      expect(screen.queryByText("🇺🇸")).not.toBeInTheDocument();
+      // Should not show country picker when phone is mixed with email
       expect(screen.queryByText("Select Country")).not.toBeInTheDocument();
     });
 
-    it("should SHOW country picker when phone is supported", () => {
-      mockInstance.transaction.allowedIdentifiers = ["email", "phone"];
+    it("should NOT show country picker when username and phone are both allowed", () => {
+      mockInstance.transaction.allowedIdentifiers = ["username", "phone"];
+      render(<LoginIdScreen />);
+
+      // Should not show country picker when phone is mixed with username
+      expect(screen.queryByText("Select Country")).not.toBeInTheDocument();
+    });
+
+    it("should SHOW country picker ONLY when phone is the sole identifier", () => {
+      mockInstance.transaction.allowedIdentifiers = ["phone"];
       mockInstance.transaction.countryCode = null;
       mockInstance.transaction.countryPrefix = null;
       render(<LoginIdScreen />);
@@ -370,8 +377,8 @@ describe("LoginIdScreen", () => {
       expect(screen.getByText("Select Country")).toBeInTheDocument();
     });
 
-    it("should call pickCountryCode when clicked", async () => {
-      mockInstance.transaction.allowedIdentifiers = ["email", "phone"];
+    it("should call pickCountryCode when clicked in phone-only mode", async () => {
+      mockInstance.transaction.allowedIdentifiers = ["phone"];
       mockInstance.transaction.countryCode = null;
       mockInstance.transaction.countryPrefix = null;
       render(<LoginIdScreen />);

--- a/src/screens/login-id/hooks/useLoginIdManager.ts
+++ b/src/screens/login-id/hooks/useLoginIdManager.ts
@@ -12,7 +12,10 @@ export const useLoginIdManager = () => {
   // Extract links for consumption by UI components
   const { signupLink, resetPasswordLink, texts, captchaImage } = screen;
 
-  const handleLoginId = (loginId: string, captcha?: string): void => {
+  const handleLoginId = async (
+    loginId: string,
+    captcha?: string,
+  ): Promise<void> => {
     const options = {
       username: loginId?.trim() || "",
       captcha: screen.isCaptchaAvailable ? captcha?.trim() : undefined,
@@ -22,16 +25,20 @@ export const useLoginIdManager = () => {
     );
   };
 
-  const handleFederatedLogin = (connectionName: string) => {
+  const handleFederatedLogin = async (connectionName: string) => {
     executeSafely(`Federated login with connection: ${connectionName}`, () =>
       loginIdInstance.federatedLogin({ connection: connectionName }),
     );
   };
 
-  const handlePasskeyLogin = () => {
+  const handlePasskeyLogin = async () => {
     if (isPasskeyEnabled) {
       executeSafely(`Passkey login`, () => loginIdInstance.passkeyLogin());
     }
+  };
+
+  const handlePickCountryCode = async () => {
+    executeSafely(`Pick country code`, () => loginIdInstance.pickCountryCode());
   };
 
   return {
@@ -39,6 +46,7 @@ export const useLoginIdManager = () => {
     handleLoginId,
     handleFederatedLogin,
     handlePasskeyLogin,
+    handlePickCountryCode,
     // --- State & Data for UI ---
     // Raw texts object - let components handle their own fallbacks
     texts: texts || {},
@@ -47,8 +55,7 @@ export const useLoginIdManager = () => {
     isForgotPasswordEnabled: isForgotPasswordEnabled === true,
     isPasskeyEnabled: isPasskeyEnabled === true,
     isCaptchaAvailable: screen.isCaptchaAvailable === true,
-    // Derived data
-    errors: transaction.errors || [],
+    errors: loginIdInstance.getError(),
     captchaImage,
     // Direct links for UI
     signupLink,

--- a/src/test/utils/screen-test-utils.tsx
+++ b/src/test/utils/screen-test-utils.tsx
@@ -70,6 +70,8 @@ export class MockConfigUtils {
       mockInstance.transaction = {};
     }
     mockInstance.transaction.errors = errors;
+    // Also configure getError() method to return the same errors
+    mockInstance.getError.mockReturnValue(errors);
   }
 
   /**

--- a/src/utils/helpers/countryUtils.ts
+++ b/src/utils/helpers/countryUtils.ts
@@ -317,13 +317,15 @@ export function transformAuth0CountryCode(
 }
 
 /**
- * Checks if phone numbers are supported based on allowed identifiers
+ * Checks if country picker should be shown - only when phone is the ONLY identifier option
  * @param identifiers - Array of allowed identifier types
- * @returns boolean indicating if phone numbers are supported
+ * @returns boolean indicating if country picker should be displayed
  */
 export function isPhoneNumberSupported(identifiers: string[]): boolean {
-  return identifiers.some((identifier) =>
-    identifier.toLowerCase().includes("phone"),
+  // Show country picker only when phone is the sole identifier option
+  return (
+    identifiers.length === 1 &&
+    identifiers.some((identifier) => identifier.toLowerCase().includes("phone"))
   );
 }
 

--- a/src/utils/helpers/countryUtils.ts
+++ b/src/utils/helpers/countryUtils.ts
@@ -1,11 +1,7 @@
 /**
  * Utility functions for handling country code data from Auth0 SDK
  */
-
-// Comprehensive country code to name and flag mapping
-// Using Unicode Regional Indicator Symbols (not ASCII, but widely supported)
 const COUNTRY_DATA: Record<string, { name: string; flag: string }> = {
-  // Complete Auth0-compatible country database
   AD: { name: "Andorra", flag: "🇦🇩" },
   AE: { name: "United Arab Emirates", flag: "🇦🇪" },
   AF: { name: "Afghanistan", flag: "🇦🇫" },
@@ -270,24 +266,17 @@ export interface Auth0CountryCode {
  * Alternative structure that might be in mock data or different SDK versions
  */
 export interface Auth0CountryCodeAlt {
-  countryCode: string; // From SDK interface
-  countryPrefix: string; // From SDK interface
+  countryCode: string;
+  countryPrefix: string;
 }
 
-/**
- * CountryCodePicker expected structure
- */
 export interface CountryCodePickerData {
-  name: string; // Country name like "India"
-  code: string; // Country code like "IN"
-  dialCode: string; // Phone code like "+91"
-  flag: string; // Flag emoji like "🇮🇳"
+  name: string;
+  code: string;
+  dialCode: string;
+  flag: string;
 }
 
-/**
- * Transforms Auth0 SDK country code data to CountryCodePicker format
- * Uses SDK interface: countryCode (string) and countryPrefix (string) as separate parameters
- */
 export function transformAuth0CountryCode(
   countryCode: string | null | undefined,
   countryPrefix?: string | null | undefined,
@@ -329,96 +318,10 @@ export function isPhoneNumberSupported(identifiers: string[]): boolean {
   );
 }
 
-/**
- * Legacy transform function for backward compatibility with object format
- * @deprecated Use transformAuth0CountryCode with separate parameters instead
- */
-export function transformAuth0CountryCodeLegacy(
-  auth0CountryCode:
-    | Auth0CountryCode
-    | Auth0CountryCodeAlt
-    | any
-    | null
-    | undefined,
-): CountryCodePickerData | undefined {
-  if (!auth0CountryCode) {
-    return undefined;
-  }
-
-  // Handle case where we get just a string (like "IN")
-  if (typeof auth0CountryCode === "string") {
-    // If it's just a country code string, we can't determine the prefix
-    // This shouldn't happen with our current setup, but adding as fallback
-    const countryInfo = COUNTRY_DATA[auth0CountryCode];
-    return countryInfo
-      ? {
-          name: countryInfo.name,
-          code: auth0CountryCode,
-          dialCode: "+??", // Unknown prefix - shouldn't happen now
-          flag: countryInfo.flag,
-        }
-      : undefined;
-  }
-
-  // Handle case where it's not an object
-  if (typeof auth0CountryCode !== "object") {
-    return undefined;
-  }
-
-  // Extract country code and prefix from different possible structures
-  let countryCode: string;
-  let countryPrefix: string;
-
-  if ("code" in auth0CountryCode && "prefix" in auth0CountryCode) {
-    // Mock data format: { code: "IN", prefix: "91" }
-    countryCode = auth0CountryCode.code;
-    countryPrefix = auth0CountryCode.prefix;
-  } else if (
-    "countryCode" in auth0CountryCode &&
-    "countryPrefix" in auth0CountryCode
-  ) {
-    // SDK interface format: { countryCode: "IN", countryPrefix: "91" }
-    countryCode = auth0CountryCode.countryCode;
-    countryPrefix = auth0CountryCode.countryPrefix;
-  } else {
-    // Invalid or unknown format
-    return undefined;
-  }
-
-  if (!countryCode) {
-    return undefined;
-  }
-
-  const countryInfo = COUNTRY_DATA[countryCode];
-
-  if (!countryInfo) {
-    // Fallback for unknown country codes
-    return {
-      name: `Country ${countryCode}`,
-      code: countryCode,
-      dialCode: `+${countryPrefix}`,
-      flag: "🏳️", // Generic flag
-    };
-  }
-
-  return {
-    name: countryInfo.name,
-    code: countryCode,
-    dialCode: `+${countryPrefix}`,
-    flag: countryInfo.flag,
-  };
-}
-
-/**
- * Gets country name from country code
- */
 export function getCountryName(countryCode: string): string {
   return COUNTRY_DATA[countryCode]?.name || `Country ${countryCode}`;
 }
 
-/**
- * Gets country flag from country code
- */
 export function getCountryFlag(countryCode: string): string {
   return COUNTRY_DATA[countryCode]?.flag || "🏳️";
 }

--- a/src/utils/helpers/countryUtils.ts
+++ b/src/utils/helpers/countryUtils.ts
@@ -1,0 +1,422 @@
+/**
+ * Utility functions for handling country code data from Auth0 SDK
+ */
+
+// Comprehensive country code to name and flag mapping
+// Using Unicode Regional Indicator Symbols (not ASCII, but widely supported)
+const COUNTRY_DATA: Record<string, { name: string; flag: string }> = {
+  // Complete Auth0-compatible country database
+  AD: { name: "Andorra", flag: "🇦🇩" },
+  AE: { name: "United Arab Emirates", flag: "🇦🇪" },
+  AF: { name: "Afghanistan", flag: "🇦🇫" },
+  AG: { name: "Antigua and Barbuda", flag: "🇦🇬" },
+  AI: { name: "Anguilla", flag: "🇦🇮" },
+  AL: { name: "Albania", flag: "🇦🇱" },
+  AM: { name: "Armenia", flag: "🇦🇲" },
+  AO: { name: "Angola", flag: "🇦🇴" },
+  AQ: { name: "Antarctica", flag: "🇦🇶" },
+  AR: { name: "Argentina", flag: "🇦🇷" },
+  AS: { name: "American Samoa", flag: "🇦🇸" },
+  AT: { name: "Austria", flag: "🇦🇹" },
+  AU: { name: "Australia", flag: "🇦🇺" },
+  AW: { name: "Aruba", flag: "🇦🇼" },
+  AX: { name: "Åland Islands", flag: "🇦🇽" },
+  AZ: { name: "Azerbaijan", flag: "🇦🇿" },
+  BA: { name: "Bosnia and Herzegovina", flag: "🇧🇦" },
+  BB: { name: "Barbados", flag: "🇧🇧" },
+  BD: { name: "Bangladesh", flag: "🇧🇩" },
+  BE: { name: "Belgium", flag: "🇧🇪" },
+  BF: { name: "Burkina Faso", flag: "🇧🇫" },
+  BG: { name: "Bulgaria", flag: "🇧🇬" },
+  BH: { name: "Bahrain", flag: "🇧🇭" },
+  BI: { name: "Burundi", flag: "🇧🇮" },
+  BJ: { name: "Benin", flag: "🇧🇯" },
+  BL: { name: "Saint Barthélemy", flag: "🇧🇱" },
+  BM: { name: "Bermuda", flag: "🇧🇲" },
+  BN: { name: "Brunei Darussalam", flag: "🇧🇳" },
+  BO: { name: "Bolivia, Plurinational State of", flag: "🇧🇴" },
+  BQ: { name: "Bonaire, Sint Eustatius and Saba", flag: "🇧🇶" },
+  BR: { name: "Brazil", flag: "🇧🇷" },
+  BS: { name: "Bahamas", flag: "🇧🇸" },
+  BT: { name: "Bhutan", flag: "🇧🇹" },
+  BV: { name: "Bouvet Island", flag: "🇧🇻" },
+  BW: { name: "Botswana", flag: "🇧🇼" },
+  BY: { name: "Belarus", flag: "🇧🇾" },
+  BZ: { name: "Belize", flag: "🇧🇿" },
+  CA: { name: "Canada", flag: "🇨🇦" },
+  CC: { name: "Cocos (Keeling) Islands", flag: "🇨🇨" },
+  CD: { name: "Congo, the Democratic Republic of the", flag: "🇨🇩" },
+  CF: { name: "Central African Republic", flag: "🇨🇫" },
+  CG: { name: "Congo", flag: "🇨🇬" },
+  CH: { name: "Switzerland", flag: "🇨🇭" },
+  CI: { name: "Côte d'Ivoire", flag: "🇨🇮" },
+  CK: { name: "Cook Islands", flag: "🇨🇰" },
+  CL: { name: "Chile", flag: "🇨🇱" },
+  CM: { name: "Cameroon", flag: "🇨🇲" },
+  CN: { name: "China", flag: "🇨🇳" },
+  CO: { name: "Colombia", flag: "🇨🇴" },
+  CR: { name: "Costa Rica", flag: "🇨🇷" },
+  CU: { name: "Cuba", flag: "🇨🇺" },
+  CV: { name: "Cape Verde", flag: "🇨🇻" },
+  CW: { name: "Curaçao", flag: "🇨🇼" },
+  CX: { name: "Christmas Island", flag: "🇨🇽" },
+  CY: { name: "Cyprus", flag: "🇨🇾" },
+  CZ: { name: "Czech Republic", flag: "🇨🇿" },
+  DE: { name: "Germany", flag: "🇩🇪" },
+  DJ: { name: "Djibouti", flag: "🇩🇯" },
+  DK: { name: "Denmark", flag: "🇩🇰" },
+  DM: { name: "Dominica", flag: "🇩🇲" },
+  DO: { name: "Dominican Republic", flag: "🇩🇴" },
+  DZ: { name: "Algeria", flag: "🇩🇿" },
+  EC: { name: "Ecuador", flag: "🇪🇨" },
+  EE: { name: "Estonia", flag: "🇪🇪" },
+  EG: { name: "Egypt", flag: "🇪🇬" },
+  EH: { name: "Western Sahara", flag: "🇪🇭" },
+  ER: { name: "Eritrea", flag: "🇪🇷" },
+  ES: { name: "Spain", flag: "🇪🇸" },
+  ET: { name: "Ethiopia", flag: "🇪🇹" },
+  FI: { name: "Finland", flag: "🇫🇮" },
+  FJ: { name: "Fiji", flag: "🇫🇯" },
+  FK: { name: "Falkland Islands (Malvinas)", flag: "🇫🇰" },
+  FM: { name: "Micronesia, Federated States of", flag: "🇫🇲" },
+  FO: { name: "Faroe Islands", flag: "🇫🇴" },
+  FR: { name: "France", flag: "🇫🇷" },
+  GA: { name: "Gabon", flag: "🇬🇦" },
+  GB: { name: "United Kingdom", flag: "🇬🇧" },
+  GD: { name: "Grenada", flag: "🇬🇩" },
+  GE: { name: "Georgia", flag: "🇬🇪" },
+  GF: { name: "French Guiana", flag: "🇬🇫" },
+  GG: { name: "Guernsey", flag: "🇬🇬" },
+  GH: { name: "Ghana", flag: "🇬🇭" },
+  GI: { name: "Gibraltar", flag: "🇬🇮" },
+  GL: { name: "Greenland", flag: "🇬🇱" },
+  GM: { name: "Gambia", flag: "🇬🇲" },
+  GN: { name: "Guinea", flag: "🇬🇳" },
+  GP: { name: "Guadeloupe", flag: "🇬🇵" },
+  GQ: { name: "Equatorial Guinea", flag: "🇬🇶" },
+  GR: { name: "Greece", flag: "🇬🇷" },
+  GS: { name: "South Georgia and the South Sandwich Islands", flag: "🇬🇸" },
+  GT: { name: "Guatemala", flag: "🇬🇹" },
+  GU: { name: "Guam", flag: "🇬🇺" },
+  GW: { name: "Guinea-Bissau", flag: "🇬🇼" },
+  GY: { name: "Guyana", flag: "🇬🇾" },
+  HK: { name: "Hong Kong", flag: "🇭🇰" },
+  HM: { name: "Heard Island and McDonald Islands", flag: "🇭🇲" },
+  HN: { name: "Honduras", flag: "🇭🇳" },
+  HR: { name: "Croatia", flag: "🇭🇷" },
+  HT: { name: "Haiti", flag: "🇭🇹" },
+  HU: { name: "Hungary", flag: "🇭🇺" },
+  ID: { name: "Indonesia", flag: "🇮🇩" },
+  IE: { name: "Ireland", flag: "🇮🇪" },
+  IL: { name: "Israel", flag: "🇮🇱" },
+  IM: { name: "Isle of Man", flag: "🇮🇲" },
+  IN: { name: "India", flag: "🇮🇳" },
+  IO: { name: "British Indian Ocean Territory", flag: "🇮🇴" },
+  IQ: { name: "Iraq", flag: "🇮🇶" },
+  IR: { name: "Iran, Islamic Republic of", flag: "🇮🇷" },
+  IS: { name: "Iceland", flag: "🇮🇸" },
+  IT: { name: "Italy", flag: "🇮🇹" },
+  JE: { name: "Jersey", flag: "🇯🇪" },
+  JM: { name: "Jamaica", flag: "🇯🇲" },
+  JO: { name: "Jordan", flag: "🇯🇴" },
+  JP: { name: "Japan", flag: "🇯🇵" },
+  KE: { name: "Kenya", flag: "🇰🇪" },
+  KG: { name: "Kyrgyzstan", flag: "🇰🇬" },
+  KH: { name: "Cambodia", flag: "🇰🇭" },
+  KI: { name: "Kiribati", flag: "🇰🇮" },
+  KM: { name: "Comoros", flag: "🇰🇲" },
+  KN: { name: "Saint Kitts and Nevis", flag: "🇰🇳" },
+  KP: { name: "Korea, Democratic People's Republic of", flag: "🇰🇵" },
+  KR: { name: "Korea, Republic of", flag: "🇰🇷" },
+  KW: { name: "Kuwait", flag: "🇰🇼" },
+  KY: { name: "Cayman Islands", flag: "🇰🇾" },
+  KZ: { name: "Kazakhstan", flag: "🇰🇿" },
+  LA: { name: "Lao People's Democratic Republic", flag: "🇱🇦" },
+  LB: { name: "Lebanon", flag: "🇱🇧" },
+  LC: { name: "Saint Lucia", flag: "🇱🇨" },
+  LI: { name: "Liechtenstein", flag: "🇱🇮" },
+  LK: { name: "Sri Lanka", flag: "🇱🇰" },
+  LR: { name: "Liberia", flag: "🇱🇷" },
+  LS: { name: "Lesotho", flag: "🇱🇸" },
+  LT: { name: "Lithuania", flag: "🇱🇹" },
+  LU: { name: "Luxembourg", flag: "🇱🇺" },
+  LV: { name: "Latvia", flag: "🇱🇻" },
+  LY: { name: "Libya", flag: "🇱🇾" },
+  MA: { name: "Morocco", flag: "🇲🇦" },
+  MC: { name: "Monaco", flag: "🇲🇨" },
+  MD: { name: "Moldova, Republic of", flag: "🇲🇩" },
+  ME: { name: "Montenegro", flag: "🇲🇪" },
+  MF: { name: "Saint Martin (French part)", flag: "🇲🇫" },
+  MG: { name: "Madagascar", flag: "🇲🇬" },
+  MH: { name: "Marshall Islands", flag: "🇲🇭" },
+  MK: { name: "Macedonia, the former Yugoslav Republic of", flag: "🇲🇰" },
+  ML: { name: "Mali", flag: "🇲🇱" },
+  MM: { name: "Myanmar", flag: "🇲🇲" },
+  MN: { name: "Mongolia", flag: "🇲🇳" },
+  MO: { name: "Macao", flag: "🇲🇴" },
+  MP: { name: "Northern Mariana Islands", flag: "🇲🇵" },
+  MQ: { name: "Martinique", flag: "🇲🇶" },
+  MR: { name: "Mauritania", flag: "🇲🇷" },
+  MS: { name: "Montserrat", flag: "🇲🇸" },
+  MT: { name: "Malta", flag: "🇲🇹" },
+  MU: { name: "Mauritius", flag: "🇲🇺" },
+  MV: { name: "Maldives", flag: "🇲🇻" },
+  MW: { name: "Malawi", flag: "🇲🇼" },
+  MX: { name: "Mexico", flag: "🇲🇽" },
+  MY: { name: "Malaysia", flag: "🇲🇾" },
+  MZ: { name: "Mozambique", flag: "🇲🇿" },
+  NA: { name: "Namibia", flag: "🇳🇦" },
+  NC: { name: "New Caledonia", flag: "🇳🇨" },
+  NE: { name: "Niger", flag: "🇳🇪" },
+  NF: { name: "Norfolk Island", flag: "🇳🇫" },
+  NG: { name: "Nigeria", flag: "🇳🇬" },
+  NI: { name: "Nicaragua", flag: "🇳🇮" },
+  NL: { name: "Netherlands", flag: "🇳🇱" },
+  NO: { name: "Norway", flag: "🇳🇴" },
+  NP: { name: "Nepal", flag: "🇳🇵" },
+  NR: { name: "Nauru", flag: "🇳🇷" },
+  NU: { name: "Niue", flag: "🇳🇺" },
+  NZ: { name: "New Zealand", flag: "🇳🇿" },
+  OM: { name: "Oman", flag: "🇴🇲" },
+  PA: { name: "Panama", flag: "🇵🇦" },
+  PE: { name: "Peru", flag: "🇵🇪" },
+  PF: { name: "French Polynesia", flag: "🇵🇫" },
+  PG: { name: "Papua New Guinea", flag: "🇵🇬" },
+  PH: { name: "Philippines", flag: "🇵🇭" },
+  PK: { name: "Pakistan", flag: "🇵🇰" },
+  PL: { name: "Poland", flag: "🇵🇱" },
+  PM: { name: "Saint Pierre and Miquelon", flag: "🇵🇲" },
+  PN: { name: "Pitcairn", flag: "🇵🇳" },
+  PR: { name: "Puerto Rico", flag: "🇵🇷" },
+  PS: { name: "Palestine, State of", flag: "🇵🇸" },
+  PT: { name: "Portugal", flag: "🇵🇹" },
+  PW: { name: "Palau", flag: "🇵🇼" },
+  PY: { name: "Paraguay", flag: "🇵🇾" },
+  QA: { name: "Qatar", flag: "🇶🇦" },
+  RE: { name: "Réunion", flag: "🇷🇪" },
+  RO: { name: "Romania", flag: "🇷🇴" },
+  RS: { name: "Serbia", flag: "🇷🇸" },
+  RU: { name: "Russian Federation", flag: "🇷🇺" },
+  RW: { name: "Rwanda", flag: "🇷🇼" },
+  SA: { name: "Saudi Arabia", flag: "🇸🇦" },
+  SB: { name: "Solomon Islands", flag: "🇸🇧" },
+  SC: { name: "Seychelles", flag: "🇸🇨" },
+  SD: { name: "Sudan", flag: "🇸🇩" },
+  SE: { name: "Sweden", flag: "🇸🇪" },
+  SG: { name: "Singapore", flag: "🇸🇬" },
+  SH: { name: "Saint Helena, Ascension and Tristan da Cunha", flag: "🇸🇭" },
+  SI: { name: "Slovenia", flag: "🇸🇮" },
+  SJ: { name: "Svalbard and Jan Mayen", flag: "🇸🇯" },
+  SK: { name: "Slovakia", flag: "🇸🇰" },
+  SL: { name: "Sierra Leone", flag: "🇸🇱" },
+  SM: { name: "San Marino", flag: "🇸🇲" },
+  SN: { name: "Senegal", flag: "🇸🇳" },
+  SO: { name: "Somalia", flag: "🇸🇴" },
+  SR: { name: "Suriname", flag: "🇸🇷" },
+  SS: { name: "South Sudan", flag: "🇸🇸" },
+  ST: { name: "Sao Tome and Principe", flag: "🇸🇹" },
+  SV: { name: "El Salvador", flag: "🇸🇻" },
+  SX: { name: "Sint Maarten (Dutch part)", flag: "🇸🇽" },
+  SY: { name: "Syrian Arab Republic", flag: "🇸🇾" },
+  SZ: { name: "Swaziland", flag: "🇸🇿" },
+  TC: { name: "Turks and Caicos Islands", flag: "🇹🇨" },
+  TD: { name: "Chad", flag: "🇹🇩" },
+  TF: { name: "French Southern Territories", flag: "🇹🇫" },
+  TG: { name: "Togo", flag: "🇹🇬" },
+  TH: { name: "Thailand", flag: "🇹🇭" },
+  TJ: { name: "Tajikistan", flag: "🇹🇯" },
+  TK: { name: "Tokelau", flag: "🇹🇰" },
+  TL: { name: "Timor-Leste", flag: "🇹🇱" },
+  TM: { name: "Turkmenistan", flag: "🇹🇲" },
+  TN: { name: "Tunisia", flag: "🇹🇳" },
+  TO: { name: "Tonga", flag: "🇹🇴" },
+  TR: { name: "Turkey", flag: "🇹🇷" },
+  TT: { name: "Trinidad and Tobago", flag: "🇹🇹" },
+  TV: { name: "Tuvalu", flag: "🇹🇻" },
+  TW: { name: "Taiwan, Province of China", flag: "🇹🇼" },
+  TZ: { name: "Tanzania, United Republic of", flag: "🇹🇿" },
+  UA: { name: "Ukraine", flag: "🇺🇦" },
+  UG: { name: "Uganda", flag: "🇺🇬" },
+  UM: { name: "United States Minor Outlying Islands", flag: "🇺🇲" },
+  US: { name: "United States", flag: "🇺🇸" },
+  UY: { name: "Uruguay", flag: "🇺🇾" },
+  UZ: { name: "Uzbekistan", flag: "🇺🇿" },
+  VA: { name: "Holy See (Vatican City State)", flag: "🇻🇦" },
+  VC: { name: "Saint Vincent and the Grenadines", flag: "🇻🇨" },
+  VE: { name: "Venezuela, Bolivarian Republic of", flag: "🇻🇪" },
+  VG: { name: "Virgin Islands, British", flag: "🇻🇬" },
+  VI: { name: "Virgin Islands, U.S.", flag: "🇻🇮" },
+  VN: { name: "Viet Nam", flag: "🇻🇳" },
+  VU: { name: "Vanuatu", flag: "🇻🇺" },
+  WF: { name: "Wallis and Futuna", flag: "🇼🇫" },
+  WS: { name: "Samoa", flag: "🇼🇸" },
+  YE: { name: "Yemen", flag: "🇾🇪" },
+  YT: { name: "Mayotte", flag: "🇾🇹" },
+  ZA: { name: "South Africa", flag: "🇿🇦" },
+  ZM: { name: "Zambia", flag: "🇿🇲" },
+  ZW: { name: "Zimbabwe", flag: "🇿🇼" },
+};
+
+/**
+ * Auth0 SDK country code structure from TransactionMembersOnLoginId
+ * Based on: https://auth0.github.io/universal-login/interfaces/Classes.TransactionMembersOnLoginId.html
+ */
+export interface Auth0CountryCode {
+  code: string; // Country code like "IN", "US"
+  prefix: string; // Phone prefix like "91", "1"
+}
+
+/**
+ * Alternative structure that might be in mock data or different SDK versions
+ */
+export interface Auth0CountryCodeAlt {
+  countryCode: string; // From SDK interface
+  countryPrefix: string; // From SDK interface
+}
+
+/**
+ * CountryCodePicker expected structure
+ */
+export interface CountryCodePickerData {
+  name: string; // Country name like "India"
+  code: string; // Country code like "IN"
+  dialCode: string; // Phone code like "+91"
+  flag: string; // Flag emoji like "🇮🇳"
+}
+
+/**
+ * Transforms Auth0 SDK country code data to CountryCodePicker format
+ * Uses SDK interface: countryCode (string) and countryPrefix (string) as separate parameters
+ */
+export function transformAuth0CountryCode(
+  countryCode: string | null | undefined,
+  countryPrefix?: string | null | undefined,
+): CountryCodePickerData | undefined {
+  if (!countryCode) {
+    return undefined;
+  }
+
+  const countryInfo = COUNTRY_DATA[countryCode];
+
+  if (!countryInfo) {
+    // Fallback for unknown country codes
+    return {
+      name: `Country ${countryCode}`,
+      code: countryCode,
+      dialCode: countryPrefix ? `+${countryPrefix}` : "+??",
+      flag: "🏳️", // Generic flag
+    };
+  }
+
+  return {
+    name: countryInfo.name,
+    code: countryCode,
+    dialCode: countryPrefix ? `+${countryPrefix}` : "+??",
+    flag: countryInfo.flag,
+  };
+}
+
+/**
+ * Checks if phone numbers are supported based on allowed identifiers
+ * @param identifiers - Array of allowed identifier types
+ * @returns boolean indicating if phone numbers are supported
+ */
+export function isPhoneNumberSupported(identifiers: string[]): boolean {
+  return identifiers.some((identifier) =>
+    identifier.toLowerCase().includes("phone"),
+  );
+}
+
+/**
+ * Legacy transform function for backward compatibility with object format
+ * @deprecated Use transformAuth0CountryCode with separate parameters instead
+ */
+export function transformAuth0CountryCodeLegacy(
+  auth0CountryCode:
+    | Auth0CountryCode
+    | Auth0CountryCodeAlt
+    | any
+    | null
+    | undefined,
+): CountryCodePickerData | undefined {
+  if (!auth0CountryCode) {
+    return undefined;
+  }
+
+  // Handle case where we get just a string (like "IN")
+  if (typeof auth0CountryCode === "string") {
+    // If it's just a country code string, we can't determine the prefix
+    // This shouldn't happen with our current setup, but adding as fallback
+    const countryInfo = COUNTRY_DATA[auth0CountryCode];
+    return countryInfo
+      ? {
+          name: countryInfo.name,
+          code: auth0CountryCode,
+          dialCode: "+??", // Unknown prefix - shouldn't happen now
+          flag: countryInfo.flag,
+        }
+      : undefined;
+  }
+
+  // Handle case where it's not an object
+  if (typeof auth0CountryCode !== "object") {
+    return undefined;
+  }
+
+  // Extract country code and prefix from different possible structures
+  let countryCode: string;
+  let countryPrefix: string;
+
+  if ("code" in auth0CountryCode && "prefix" in auth0CountryCode) {
+    // Mock data format: { code: "IN", prefix: "91" }
+    countryCode = auth0CountryCode.code;
+    countryPrefix = auth0CountryCode.prefix;
+  } else if (
+    "countryCode" in auth0CountryCode &&
+    "countryPrefix" in auth0CountryCode
+  ) {
+    // SDK interface format: { countryCode: "IN", countryPrefix: "91" }
+    countryCode = auth0CountryCode.countryCode;
+    countryPrefix = auth0CountryCode.countryPrefix;
+  } else {
+    // Invalid or unknown format
+    return undefined;
+  }
+
+  if (!countryCode) {
+    return undefined;
+  }
+
+  const countryInfo = COUNTRY_DATA[countryCode];
+
+  if (!countryInfo) {
+    // Fallback for unknown country codes
+    return {
+      name: `Country ${countryCode}`,
+      code: countryCode,
+      dialCode: `+${countryPrefix}`,
+      flag: "🏳️", // Generic flag
+    };
+  }
+
+  return {
+    name: countryInfo.name,
+    code: countryCode,
+    dialCode: `+${countryPrefix}`,
+    flag: countryInfo.flag,
+  };
+}
+
+/**
+ * Gets country name from country code
+ */
+export function getCountryName(countryCode: string): string {
+  return COUNTRY_DATA[countryCode]?.name || `Country ${countryCode}`;
+}
+
+/**
+ * Gets country flag from country code
+ */
+export function getCountryFlag(countryCode: string): string {
+  return COUNTRY_DATA[countryCode]?.flag || "🏳️";
+}


### PR DESCRIPTION
## Description
Country code picker component addition when identifier selected is phone number only. `pickCountry()` action integrated for `login-id` screen.

<img width="381" height="689" alt="image" src="https://github.com/user-attachments/assets/9b963963-d52d-4a8e-a2f5-af66b5a74632" />

## Changes
- New method addition for `login-id` - `pickCountry()`
- Form actions updated to `async`
- Test cases updated to use `getError()` for `loginIdInstance()`
- `PickCountryCode` custom component addition
- New utility for flags and rendering `PickCountryCode` componenent based on identifier.
- Other documentation updates

## Testing
### Local testing
1. Update mockdata - `login-id.json` with to have only phone as identifier
```json
"transaction": {
.....
 "connection": {
      "name": "Username-Password-Authentication",
      "strategy": "auth0",
      "options": {
        "signup_enabled": true,
        "forgot_password_enabled": true,
        "attributes": {
          "phone": {
            "signup_status": "required",
            "identifier_active": true
          }
        }
      }
    }
......
}
```

2. Run `npm run screen login-id` .

### Testing with tenant setting.
1. Go to Auth0 [dashboard](https://manage.auth0.com/),  navigate to Authentication -> Database -> Username-password -Authentication.

<img width="1948" height="858" alt="image" src="https://github.com/user-attachments/assets/bd6539a2-3822-4a13-95d4-1f81908c1821" />

2. Select only `Phone Number` Attribute and enable it.

3. Upload your assets for `login-id`, Render screen in advanced mode. 

4. Done.